### PR TITLE
SSE: Just use Stream instead of SseSender

### DIFF
--- a/actix-web-lab/CHANGELOG.md
+++ b/actix-web-lab/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Remove `sse::Sender` type.
+- Remove `sse::ChannelStream` type.
+- Remove `sse::channel` function.
+- Add `sse::Sse::from_infallible_stream()` method.
+- Add `sse::Sse::{from_receiver, from_infallible_receiver}()` methods.
+
 ## 0.19.2
 
 - Add `extract::ReconstructedPath` extractor.

--- a/actix-web-lab/Cargo.toml
+++ b/actix-web-lab/Cargo.toml
@@ -57,6 +57,7 @@ serde = "1"
 serde_html_form = "0.2"
 serde_json = "1"
 tokio = { version = "1.18.5", features = ["sync", "macros"] }
+tokio-stream = "0.1.14"
 tracing = { version = "0.1.30", features = ["log"] }
 
 # cbor

--- a/actix-web-lab/Cargo.toml
+++ b/actix-web-lab/Cargo.toml
@@ -57,7 +57,7 @@ serde = "1"
 serde_html_form = "0.2"
 serde_json = "1"
 tokio = { version = "1.18.5", features = ["sync", "macros"] }
-tokio-stream = "0.1.14"
+tokio-stream = "0.1.1"
 tracing = { version = "0.1.30", features = ["log"] }
 
 # cbor

--- a/actix-web-lab/src/sse.rs
+++ b/actix-web-lab/src/sse.rs
@@ -309,6 +309,9 @@ impl Event {
 
 pin_project! {
     /// Server-sent events (`text/event-stream`) responder.
+    ///
+    /// Constructed using a [Tokio channel](Self::from_receiver) or using your [own
+    /// stream](Self::from_stream).
     #[must_use]
     #[derive(Debug)]
     pub struct Sse<S> {

--- a/actix-web-lab/src/sse.rs
+++ b/actix-web-lab/src/sse.rs
@@ -1,4 +1,4 @@
-//! Semantic server-sent events (SSE) responder with a channel-like interface.
+//! Semantic server-sent events (SSE) responder
 //!
 //! # Examples
 //! ```no_run
@@ -6,19 +6,6 @@
 //!
 //! use actix_web::{get, Responder};
 //! use actix_web_lab::sse;
-//!
-//! #[get("/from-channel")]
-//! async fn from_channel() -> impl Responder {
-//!     let (sender, sse_stream) = sse::channel(10);
-//!
-//!     // note: sender will typically be spawned or handed off somewhere else
-//!     let _ = sender.send(sse::Event::Comment("my comment".into())).await;
-//!     let _ = sender
-//!         .send(sse::Data::new("my data").event("chat_msg"))
-//!         .await;
-//!
-//!     sse_stream.with_retry_duration(Duration::from_secs(10))
-//! }
 //!
 //! #[get("/from-stream")]
 //! async fn from_stream() -> impl Responder {
@@ -59,12 +46,14 @@ use futures_core::Stream;
 use pin_project_lite::pin_project;
 use serde::Serialize;
 use tokio::{
-    sync::mpsc,
+    sync::mpsc::{self, Receiver},
     time::{interval, Interval},
 };
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::{
     header::{CacheControl, CacheDirective},
+    util::InfallibleStream,
     BoxError,
 };
 
@@ -307,69 +296,8 @@ impl Event {
     }
 }
 
-/// Sender half of a server-sent events stream.
-#[must_use]
-#[derive(Debug, Clone)]
-pub struct Sender {
-    tx: mpsc::Sender<Event>,
-}
-
-#[doc(hidden)]
-#[deprecated(since = "0.17.0", note = "Renamed to `Sender`. Prefer `sse::Sender`.")]
-pub type SseSender = Sender;
-
-impl Sender {
-    /// Send an SSE message.
-    ///
-    /// # Errors
-    /// Errors if the receiving ([`Sse`]) has been dropped, likely because the client disconnected.
-    ///
-    /// # Examples
-    /// ```
-    /// #[actix_web::main] async fn test() {
-    /// use actix_web_lab::sse;
-    ///
-    /// let (sender, sse_stream) = sse::channel(5);
-    /// sender.send(sse::Data::new("my data").event("my event name")).await.unwrap();
-    /// sender.send(sse::Event::Comment("my comment".into())).await.unwrap();
-    /// # } test();
-    /// ```
-    pub async fn send(&self, msg: impl Into<Event>) -> Result<(), SendError> {
-        self.tx
-            .send(msg.into())
-            .await
-            .map_err(|mpsc::error::SendError(ev)| SendError(ev))
-    }
-
-    /// Tries to send SSE message.
-    ///
-    /// # Errors
-    /// Errors if:
-    /// - the the SSE buffer is currently full;
-    /// - the receiving ([`Sse`]) has been dropped, likely because the client disconnected.
-    ///
-    /// # Examples
-    /// ```
-    /// #[actix_web::main] async fn test() {
-    /// use actix_web_lab::sse;
-    ///
-    /// let (sender, sse_stream) = sse::channel(5);
-    /// sender.try_send(sse::Data::new("my data").event("my event name")).unwrap();
-    /// sender.try_send(sse::Event::Comment("my comment".into())).unwrap();
-    /// # } test();
-    /// ```
-    pub fn try_send(&self, msg: impl Into<Event>) -> Result<(), TrySendError> {
-        self.tx.try_send(msg.into()).map_err(|err| match err {
-            mpsc::error::TrySendError::Full(ev) => TrySendError::Full(ev),
-            mpsc::error::TrySendError::Closed(ev) => TrySendError::Closed(ev),
-        })
-    }
-}
-
 pin_project! {
     /// Server-sent events (`text/event-stream`) responder.
-    ///
-    /// Constructed with an [SSE channel](channel) or [using your own stream](Self::from_stream).
     #[must_use]
     #[derive(Debug)]
     pub struct Sse<S> {
@@ -392,6 +320,33 @@ where
             keep_alive: None,
             retry_interval: None,
         }
+    }
+}
+
+impl<S> Sse<InfallibleStream<S>>
+where
+    S: Stream<Item = Event> + 'static,
+{
+    /// Create an SSE response from an infallible stream that yields SSE [Event]s.
+    pub fn from_infallible_stream(stream: S) -> Self {
+        Sse::from_stream(InfallibleStream::new(stream))
+    }
+}
+
+impl<E> Sse<ReceiverStream<Result<Event, E>>>
+where
+    E: Into<BoxError> + 'static,
+{
+    /// Create an SSE response from a receiver that yields SSE [Event]s.
+    pub fn from_receiver(receiver: Receiver<Result<Event, E>>) -> Self {
+        Self::from_stream(ReceiverStream::new(receiver))
+    }
+}
+
+impl Sse<InfallibleStream<ReceiverStream<Event>>> {
+    /// Create an SSE response from a receiver that yields SSE [Event]s.
+    pub fn from_infallible_receiver(receiver: Receiver<Event>) -> Self {
+        Self::from_stream(InfallibleStream::new(ReceiverStream::new(receiver)))
     }
 }
 
@@ -472,47 +427,6 @@ where
     }
 }
 
-/// Create server-sent events (SSE) channel pair.
-///
-/// The `buffer` argument controls how many unsent messages can be stored without waiting.
-///
-/// The first item in the tuple is the sender half. Much like a regular channel, it can be cloned,
-/// sent to another thread/task, and send event messages to the response stream. It provides several
-/// methods that represent the event-stream format.
-///
-/// The second item is the responder and can, therefore, be used as a handler return type directly.
-/// The stream will be closed after all [senders](SseSender) are dropped.
-///
-/// Read more about server-sent events in [this MDN article][mdn-sse].
-///
-/// See [module docs](self) for usage example.
-///
-/// [mdn-sse]: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
-pub fn channel(buffer: usize) -> (Sender, Sse<ChannelStream>) {
-    let (tx, rx) = mpsc::channel(buffer);
-
-    (
-        Sender { tx },
-        Sse {
-            stream: ChannelStream(rx),
-            keep_alive: None,
-            retry_interval: None,
-        },
-    )
-}
-
-/// Stream implementation for channel-based SSE [`Sender`].
-#[derive(Debug)]
-pub struct ChannelStream(mpsc::Receiver<Event>);
-
-impl Stream for ChannelStream {
-    type Item = Result<Event, Infallible>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.0.poll_recv(cx).map(|ev| ev.map(Ok))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;
@@ -522,7 +436,7 @@ mod tests {
     use tokio::time::sleep;
 
     use super::*;
-    use crate::assert_response_matches;
+    use crate::{assert_response_matches, util::InfallibleStream};
 
     #[test]
     fn format_retry_message() {
@@ -607,27 +521,12 @@ mod tests {
         let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
 
-        {
-            let (_sender, mut sse) = channel(9);
-            assert!(Pin::new(&mut sse).poll_next(&mut cx).is_pending());
+        let mut sse = Sse::from_stream(InfallibleStream::new(tokio_stream::empty()))
+            .with_retry_duration(Duration::from_millis(42));
+        match Pin::new(&mut sse).poll_next(&mut cx) {
+            Poll::Ready(Some(Ok(bytes))) => assert_eq!(bytes, "retry: 42\n\n"),
+            res => panic!("poll should return retry message, got {res:?}"),
         }
-
-        {
-            let (_sender, sse) = channel(9);
-            let mut sse = sse.with_retry_duration(Duration::from_millis(42));
-            match Pin::new(&mut sse).poll_next(&mut cx) {
-                Poll::Ready(Some(Ok(bytes))) => assert_eq!(bytes, "retry: 42\n\n"),
-                res => panic!("poll should return retry message, got {res:?}"),
-            }
-        }
-    }
-
-    #[actix_web::test]
-    async fn dropping_responder_causes_send_fails() {
-        let (sender, sse) = channel(9);
-        drop(sse);
-
-        assert!(sender.send(Data::new("late data")).await.is_err());
     }
 
     #[actix_web::test]
@@ -664,13 +563,17 @@ mod tests {
 
     #[actix_web::test]
     async fn messages_are_received_from_sender() {
-        let (sender, mut sse) = channel(9);
+        let (sender, receiver) = tokio::sync::mpsc::channel(2);
+        let mut sse = Sse::from_infallible_receiver(receiver);
 
         assert!(poll_fn(|cx| Pin::new(&mut sse).poll_next(cx))
             .now_or_never()
             .is_none());
 
-        sender.send(Data::new("bar").event("foo")).await.unwrap();
+        sender
+            .send(Data::new("bar").event("foo").into())
+            .await
+            .unwrap();
 
         match poll_fn(|cx| Pin::new(&mut sse).poll_next(cx)).now_or_never() {
             Some(Some(Ok(bytes))) => assert_eq!(bytes, "event: foo\ndata: bar\n\n"),
@@ -683,8 +586,9 @@ mod tests {
         let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
 
-        let (sender, sse) = channel(9);
-        let mut sse = sse.with_keep_alive(Duration::from_millis(4));
+        let (sender, receiver) = tokio::sync::mpsc::channel(2);
+        let mut sse =
+            Sse::from_infallible_receiver(receiver).with_keep_alive(Duration::from_millis(4));
 
         assert!(Pin::new(&mut sse).poll_next(&mut cx).is_pending());
 
@@ -697,7 +601,7 @@ mod tests {
 
         assert!(Pin::new(&mut sse).poll_next(&mut cx).is_pending());
 
-        sender.send(Data::new("foo")).await.unwrap();
+        sender.send(Data::new("foo").into()).await.unwrap();
 
         match Pin::new(&mut sse).poll_next(&mut cx) {
             Poll::Ready(Some(Ok(bytes))) => assert_eq!(bytes, "data: foo\n\n"),


### PR DESCRIPTION
Looking at the SSE examples, an odd part for me is to use an SSE specific channel call to get a SseSender and use that in a producer. This PR shows that it can be independent of the channel type by sticking to the concept that any Stream trait object can be a producer of server-sent events. So all I need in a producer is something which is Stream eventually.

If an unbounded channel or a different kind of channel is preferred by the user it should be obvious that SSE is not imposing any special requirement on the channel type. It just needs to be Stream eventually.

I view the SSE Responder in this case as a consumer of SSE events and the producer is the user defined thing producing eventually SSE events or things which can be turned into SSE events.

Funnily tokio mpsc bounded Receiver is not implementing Stream itself but tokio-stream provides a ReceiverStream wrapper type which takes the Receiver and implements Stream. Here in the PR I introduced `Sse::from_receiver` to be a bit more convenient in this regard. The user does not need to use the tokio-stream dependency by himself.

There are multiple `Sse::from_*` functions now and it is maybe not the best pattern here. I need feedback if maybe another trait and From implementations for this trait and Receiver (and all the other tokio receiver types) are better such that `Sse::from` can be used in all cases.

After wrapping a Receiver in  a ReceiverStream a user could now also call map on it. So it is more composable than receiver types by themself. For example this allows patterns where the data producer is independent of SSE, for example produces a user defined type or String and than the stream is mapped into Sse::Data.

## Other feedback to this SSE interface

When the producer is not channels based but a stream by itself, for example a streaming answer from some database query, I can imagine that this is mapped quite well to SSE events. So this is good.

I got confused by the use of Infallible in the examples because I did not knew Infallible. It also feels a bit clunky to produce Results of Events in a stream. It is discouraging when the example needs to use turbofish to say that there are no errors.
`Ok::<_, Infallible>(sse::Event::Data(data))` Can this be more convenient? Would have expected just `Ok(data)`.

`Sse::Event::Comment` confused me and I needed to look SSE comments up in MDN to find out that they are actually not showing up on the client side javascript events. I think they don't need to be so prominent in the examples.

Thanks @cjrh for the great discussions on this during #EuroRust23 🦀