### PR TITLE
Adjusted http upgrade to use url crate to parse hostnames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/actix-web-lab/CHANGELOG.md
+++ b/actix-web-lab/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `RedirectHttps` middleware when used with IPv6 addresses.
+
 ## 0.24.0
 
 - Re-work `Json` extractor error handling.

--- a/actix-web-lab/Cargo.toml
+++ b/actix-web-lab/Cargo.toml
@@ -76,6 +76,7 @@ serde_path_to_error = "0.1"
 tokio = { version = "1.43.0", features = ["sync", "macros"] }
 tokio-stream = "0.1.17"
 tracing = { version = "0.1.41", features = ["log"] }
+url = "2.1"
 
 # cbor
 serde_cbor_2 = { version = "0.12.0-dev", optional = true }

--- a/actix-web-lab/src/redirect_to_https.rs
+++ b/actix-web-lab/src/redirect_to_https.rs
@@ -119,7 +119,11 @@ where
                 let host = conn_info.host();
 
                 // construct equivalent https path
-                let (hostname, _port) = host.split_once(':').unwrap_or((host, ""));
+                let parsed_url = url::Url::parse(&format!("http://{host}"));
+                let hostname = match &parsed_url {
+                    Ok(url) => url.host_str().unwrap_or(""),
+                    Err(_) => host.split_once(':').map_or("", |(host, _port)| host),
+                };
 
                 let path = req.uri().path();
                 let uri = match port {

--- a/actix-web-lab/src/redirect_to_https.rs
+++ b/actix-web-lab/src/redirect_to_https.rs
@@ -272,6 +272,18 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn to_ipv6() {
+        let app = RedirectHttps::default()
+            .new_transform(test::ok_service())
+            .await
+            .unwrap();
+
+        let req = test_request!(GET "http://[fe80::1234:1234:1234:1234]/").to_srv_request();
+        let res = test::call_service(&app, req).await;
+        assert_response_matches!(res, TEMPORARY_REDIRECT; "location" => "https://[fe80::1234:1234:1234:1234]/");
+    }
+
+    #[actix_web::test]
     async fn to_custom_port_when_port_in_host() {
         let app = RedirectHttps::default()
             .to_port(8443)


### PR DESCRIPTION
Closes #159

Using url crate with version 2.1 to match Actix-Web