### PR TITLE
Add PROXY protocol v2 header parsing

### DIFF
--- a/actix-proxy-protocol/examples/proxy-server.rs
+++ b/actix-proxy-protocol/examples/proxy-server.rs
@@ -81,7 +81,7 @@ async fn wrap_with_proxy_protocol_v2(mut stream: TcpStream) -> io::Result<()> {
     proxy_header.add_typed_tlv(tlv::Noop::new("NOOP m8")); // NOOP
     proxy_header.add_typed_tlv(tlv::Authority::new("localhost")); // NOOP
     proxy_header.add_typed_tlv(tlv::Alpn::new("http/1.1")); // NOOP
-    proxy_header.add_crc23c_checksum();
+    proxy_header.add_crc32c_checksum();
 
     proxy_header.write_to_tokio(&mut upstream).await?;
 

--- a/actix-proxy-protocol/src/lib.rs
+++ b/actix-proxy-protocol/src/lib.rs
@@ -1,16 +1,17 @@
-//! PROXY protocol.
+//! PROXY protocol utilities for Actix networking.
 
-#![expect(dead_code)]
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
+
+use std::{fmt, io};
 
 pub mod tlv;
 pub mod v1;
 pub mod v2;
 
 /// PROXY Protocol Version.
-#[derive(Debug, Clone, Copy)]
-enum Version {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Version {
     /// Human-readable header format (Version 1)
     V1,
 
@@ -19,13 +20,6 @@ enum Version {
 }
 
 impl Version {
-    const fn signature(&self) -> &'static [u8] {
-        match self {
-            Version::V1 => v1::SIGNATURE.as_bytes(),
-            Version::V2 => v2::SIGNATURE.as_slice(),
-        }
-    }
-
     const fn v2_hi(&self) -> u8 {
         (match self {
             Version::V1 => panic!("v1 not supported in PROXY v2"),
@@ -38,7 +32,7 @@ impl Version {
 ///
 /// other values are unassigned and must not be emitted by senders. Receivers
 /// must drop connections presenting unexpected values here.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Command {
     /// \x0 : LOCAL : the connection was established on purpose by the proxy
     /// without being relayed. The connection endpoints are the sender and the
@@ -55,6 +49,14 @@ pub enum Command {
 }
 
 impl Command {
+    pub(crate) const fn from_v2_lo(val: u8) -> Option<Self> {
+        match val {
+            0x0 => Some(Self::Local),
+            0x1 => Some(Self::Proxy),
+            _ => None,
+        }
+    }
+
     const fn v2_lo(&self) -> u8 {
         match self {
             Command::Local => 0x0,
@@ -70,7 +72,7 @@ impl Command {
 ///
 /// other values are unspecified and must not be emitted in version 2 of this
 /// protocol and must be rejected as invalid by receivers.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AddressFamily {
     /// 0x0 : AF_UNSPEC : the connection is forwarded for an unknown, unspecified
     /// or unsupported protocol. The sender should use this family when sending
@@ -103,6 +105,16 @@ impl AddressFamily {
         }
     }
 
+    pub(crate) const fn from_v2_hi(val: u8) -> Option<Self> {
+        match val {
+            0x0 => Some(Self::Unspecified),
+            0x1 => Some(Self::Inet),
+            0x2 => Some(Self::Inet6),
+            0x3 => Some(Self::Unix),
+            _ => None,
+        }
+    }
+
     const fn v2_hi(&self) -> u8 {
         (match self {
             AddressFamily::Unspecified => 0x0,
@@ -117,7 +129,7 @@ impl AddressFamily {
 ///
 /// other values are unspecified and must not be emitted in version 2 of this
 /// protocol and must be rejected as invalid by receivers.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransportProtocol {
     /// 0x0 : UNSPEC : the connection is forwarded for an unknown, unspecified
     /// or unsupported protocol. The sender should use this family when sending
@@ -140,6 +152,15 @@ pub enum TransportProtocol {
 }
 
 impl TransportProtocol {
+    pub(crate) const fn from_v2_lo(val: u8) -> Option<Self> {
+        match val {
+            0x0 => Some(Self::Unspecified),
+            0x1 => Some(Self::Stream),
+            0x2 => Some(Self::Datagram),
+            _ => None,
+        }
+    }
+
     const fn v2_lo(&self) -> u8 {
         match self {
             TransportProtocol::Unspecified => 0x0,
@@ -149,8 +170,52 @@ impl TransportProtocol {
     }
 }
 
+/// PROXY protocol parse error.
 #[derive(Debug)]
-enum ProxyProtocolHeader {
-    V1(v1::Header),
-    V2(v2::Header),
+pub struct ParseError {
+    kind: ParseErrorKind,
+}
+
+#[derive(Debug)]
+enum ParseErrorKind {
+    Invalid(&'static str),
+    Io(io::Error),
+}
+
+impl ParseError {
+    pub(crate) fn invalid(message: &'static str) -> Self {
+        Self {
+            kind: ParseErrorKind::Invalid(message),
+        }
+    }
+
+    pub(crate) fn io(err: io::Error) -> Self {
+        Self {
+            kind: ParseErrorKind::Io(err),
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            ParseErrorKind::Invalid(message) => f.write_str(message),
+            ParseErrorKind::Io(err) => fmt::Display::fmt(err, f),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            ParseErrorKind::Invalid(_) => None,
+            ParseErrorKind::Io(err) => Some(err),
+        }
+    }
+}
+
+impl From<io::Error> for ParseError {
+    fn from(err: io::Error) -> Self {
+        Self::io(err)
+    }
 }

--- a/actix-proxy-protocol/src/tlv.rs
+++ b/actix-proxy-protocol/src/tlv.rs
@@ -1,6 +1,6 @@
 //! Type-length-value helpers for PROXY protocol v2 headers.
 
-use std::{borrow::Cow, str};
+use std::borrow::Cow;
 
 const PP2_TYPE_ALPN: u8 = 0x01; //           done
 const PP2_TYPE_AUTHORITY: u8 = 0x02; //      done

--- a/actix-proxy-protocol/src/v2.rs
+++ b/actix-proxy-protocol/src/v2.rs
@@ -2,14 +2,14 @@
 
 use std::{
     io,
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
 };
 
 use smallvec::{SmallVec, ToSmallVec as _};
 use tokio::io::{AsyncWrite, AsyncWriteExt as _};
 
 use crate::{
-    AddressFamily, Command, TransportProtocol, Version,
+    AddressFamily, Command, ParseError, TransportProtocol, Version,
     tlv::{Crc32c, Tlv},
 };
 
@@ -18,19 +18,84 @@ pub const SIGNATURE: [u8; 12] = [
     0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A,
 ];
 
+/// UNIX socket address byte length used by PROXY protocol v2.
+pub const UNIX_ADDR_LEN: usize = 108;
+
+type RawTlvs = SmallVec<[(u8, SmallVec<[u8; 16]>); 4]>;
+
+/// Address information carried by a PROXY protocol v2 header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Addresses {
+    /// No address information is carried.
+    Unspecified,
+
+    /// TCP or UDP IP socket addresses.
+    Inet {
+        /// Source socket address.
+        source: SocketAddr,
+
+        /// Destination socket address.
+        destination: SocketAddr,
+    },
+
+    /// UNIX socket addresses.
+    Unix {
+        /// Source socket path bytes.
+        source: Box<[u8; UNIX_ADDR_LEN]>,
+
+        /// Destination socket path bytes.
+        destination: Box<[u8; UNIX_ADDR_LEN]>,
+    },
+}
+
+impl Addresses {
+    fn address_family(&self) -> AddressFamily {
+        match self {
+            Self::Unspecified => AddressFamily::Unspecified,
+            Self::Inet { source, .. } if source.is_ipv4() => AddressFamily::Inet,
+            Self::Inet { .. } => AddressFamily::Inet6,
+            Self::Unix { .. } => AddressFamily::Unix,
+        }
+    }
+
+    fn encoded_len(&self) -> usize {
+        match self {
+            Self::Unspecified => 0,
+            Self::Inet { source, .. } if source.is_ipv4() => 12,
+            Self::Inet { .. } => 36,
+            Self::Unix { .. } => UNIX_ADDR_LEN * 2,
+        }
+    }
+
+    fn source_addr(&self) -> Option<SocketAddr> {
+        match self {
+            Self::Inet { source, .. } => Some(*source),
+            Self::Unspecified | Self::Unix { .. } => None,
+        }
+    }
+
+    fn destination_addr(&self) -> Option<SocketAddr> {
+        match self {
+            Self::Inet { destination, .. } => Some(*destination),
+            Self::Unspecified | Self::Unix { .. } => None,
+        }
+    }
+}
+
 /// PROXY protocol v2 header.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Header {
     command: Command,
     transport_protocol: TransportProtocol,
-    address_family: AddressFamily,
-    src: SocketAddr,
-    dst: SocketAddr,
-    tlvs: SmallVec<[(u8, SmallVec<[u8; 16]>); 4]>,
+    addresses: Addresses,
+    tlvs: RawTlvs,
 }
 
 impl Header {
     /// Constructs a new PROXY protocol v2 header.
+    ///
+    /// # Panics
+    /// Panics if `address_family` does not match `src` and `dst`.
     pub fn new(
         command: Command,
         transport_protocol: TransportProtocol,
@@ -38,12 +103,53 @@ impl Header {
         src: impl Into<SocketAddr>,
         dst: impl Into<SocketAddr>,
     ) -> Self {
+        let source = src.into();
+        let destination = dst.into();
+
+        assert!(
+            matches!(
+                (address_family, source, destination),
+                (AddressFamily::Inet, SocketAddr::V4(_), SocketAddr::V4(_))
+                    | (AddressFamily::Inet6, SocketAddr::V6(_), SocketAddr::V6(_))
+            ),
+            "socket addresses must match the PROXY v2 address family"
+        );
+
         Self {
             command,
             transport_protocol,
-            address_family,
-            src: src.into(),
-            dst: dst.into(),
+            addresses: Addresses::Inet {
+                source,
+                destination,
+            },
+            tlvs: SmallVec::new(),
+        }
+    }
+
+    /// Constructs a new header without address information.
+    pub fn new_unspecified(command: Command) -> Self {
+        Self {
+            command,
+            transport_protocol: TransportProtocol::Unspecified,
+            addresses: Addresses::Unspecified,
+            tlvs: SmallVec::new(),
+        }
+    }
+
+    /// Constructs a new UNIX socket header.
+    pub fn new_unix(
+        command: Command,
+        transport_protocol: TransportProtocol,
+        source: [u8; UNIX_ADDR_LEN],
+        destination: [u8; UNIX_ADDR_LEN],
+    ) -> Self {
+        Self {
+            command,
+            transport_protocol,
+            addresses: Addresses::Unix {
+                source: Box::new(source),
+                destination: Box::new(destination),
+            },
             tlvs: SmallVec::new(),
         }
     }
@@ -59,6 +165,61 @@ impl Header {
         )
     }
 
+    /// Constructs a new TCP/IPv6 PROXY command header.
+    pub fn new_tcp_ipv6_proxy(src: impl Into<SocketAddr>, dst: impl Into<SocketAddr>) -> Self {
+        Self::new(
+            Command::Proxy,
+            TransportProtocol::Stream,
+            AddressFamily::Inet6,
+            src,
+            dst,
+        )
+    }
+
+    /// Returns the header command.
+    pub const fn command(&self) -> Command {
+        self.command
+    }
+
+    /// Returns the transport protocol.
+    pub const fn transport_protocol(&self) -> TransportProtocol {
+        self.transport_protocol
+    }
+
+    /// Returns the address family.
+    pub fn address_family(&self) -> AddressFamily {
+        self.addresses.address_family()
+    }
+
+    /// Returns the encoded address information.
+    pub const fn addresses(&self) -> &Addresses {
+        &self.addresses
+    }
+
+    /// Returns the source socket address for IP headers.
+    pub fn source_addr(&self) -> Option<SocketAddr> {
+        self.addresses.source_addr()
+    }
+
+    /// Returns the destination socket address for IP headers.
+    pub fn destination_addr(&self) -> Option<SocketAddr> {
+        self.addresses.destination_addr()
+    }
+
+    /// Returns raw TLVs as `(type, value)` pairs.
+    pub fn tlvs(&self) -> impl Iterator<Item = (u8, &[u8])> {
+        self.tlvs
+            .iter()
+            .map(|(typ, value)| (*typ, value.as_slice()))
+    }
+
+    /// Returns the first TLV that decodes as `T`.
+    pub fn typed_tlv<T: Tlv>(&self) -> Option<T> {
+        self.tlvs
+            .iter()
+            .find_map(|(typ, value)| T::try_from_parts(*typ, value))
+    }
+
     /// Adds a raw TLV entry.
     pub fn add_tlv(&mut self, typ: u8, value: impl AsRef<[u8]>) {
         self.tlvs.push((typ, SmallVec::from_slice(value.as_ref())));
@@ -70,52 +231,54 @@ impl Header {
     }
 
     fn v2_len(&self) -> u16 {
-        let addr_len = if self.src.is_ipv4() {
-            4 + 2 // 4b IPv4 + 2b port number
-        } else {
-            16 + 2 // 16b IPv6 + 2b port number
-        };
-
-        (addr_len * 2)
+        (self.addresses.encoded_len()
             + self
                 .tlvs
                 .iter()
-                .map(|(_, value)| 1 + 2 + value.len() as u16)
-                .sum::<u16>()
+                .map(|(_, value)| 1 + 2 + value.len())
+                .sum::<usize>())
+        .try_into()
+        .expect("PROXY v2 header length exceeds u16::MAX")
     }
 
     /// Writes this header to an I/O writer.
     pub fn write_to(&self, wrt: &mut impl io::Write) -> io::Result<()> {
-        // PROXY v2 signature
+        // PROXY v2 signature.
         wrt.write_all(&SIGNATURE)?;
 
-        // version | command
+        // Version and command.
         wrt.write_all(&[Version::V2.v2_hi() | self.command.v2_lo()])?;
 
-        // address family | transport protocol
-        wrt.write_all(&[self.address_family.v2_hi() | self.transport_protocol.v2_lo()])?;
+        // Address family and transport protocol.
+        wrt.write_all(&[self.address_family().v2_hi() | self.transport_protocol.v2_lo()])?;
 
-        // rest-of-header length
+        // Variable header length.
         wrt.write_all(&self.v2_len().to_be_bytes())?;
 
-        tracing::debug!("proxy rest-of-header len: {}", self.v2_len());
+        match &self.addresses {
+            Addresses::Unspecified => {}
+            Addresses::Inet {
+                source,
+                destination,
+            } => {
+                // L3 IP addresses.
+                write_ip_bytes_to(wrt, source.ip())?;
+                write_ip_bytes_to(wrt, destination.ip())?;
 
-        fn write_ip_bytes_to(wrt: &mut impl io::Write, ip: IpAddr) -> io::Result<()> {
-            match ip {
-                IpAddr::V4(ip) => wrt.write_all(&ip.octets()),
-                IpAddr::V6(ip) => wrt.write_all(&ip.octets()),
+                // L4 ports.
+                wrt.write_all(&source.port().to_be_bytes())?;
+                wrt.write_all(&destination.port().to_be_bytes())?;
+            }
+            Addresses::Unix {
+                source,
+                destination,
+            } => {
+                wrt.write_all(source.as_slice())?;
+                wrt.write_all(destination.as_slice())?;
             }
         }
 
-        // L3 (IP) address
-        write_ip_bytes_to(wrt, self.src.ip())?;
-        write_ip_bytes_to(wrt, self.dst.ip())?;
-
-        // L4 ports
-        wrt.write_all(&self.src.port().to_be_bytes())?;
-        wrt.write_all(&self.dst.port().to_be_bytes())?;
-
-        // TLVs
+        // TLVs.
         for (typ, value) in &self.tlvs {
             wrt.write_all(&[*typ])?;
             wrt.write_all(&(value.len() as u16).to_be_bytes())?;
@@ -131,10 +294,16 @@ impl Header {
         wrt.write_all(&buf).await
     }
 
-    fn to_vec(&self) -> Vec<u8> {
+    /// Serializes this header to bytes.
+    pub fn to_vec(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(16 + self.v2_len() as usize);
         self.write_to(&mut buf).unwrap();
         buf
+    }
+
+    /// Attempts to parse a PROXY protocol v2 header from bytes.
+    pub fn try_from_bytes(slice: &[u8]) -> Result<(&[u8], Self), ParseError> {
+        parse(slice)
     }
 
     /// Returns true when this header contains a TLV with type `T`.
@@ -147,53 +316,46 @@ impl Header {
     /// Uses method defined in spec.
     ///
     /// If this is not called last thing it will be wrong.
-    pub fn add_crc23c_checksum(&mut self) {
-        // don't add a checksum if it is already set
+    pub fn add_crc32c_checksum(&mut self) {
+        // Don't add a checksum if it is already set.
         if self.has_tlv::<Crc32c>() {
             return;
         }
 
         // When the checksum is supported by the sender after constructing the header
         // the sender MUST:
-        // - initialize the checksum field to '0's.
+        // - initialize the checksum field to `0`s.
         // - calculate the CRC32c checksum of the PROXY header as described in RFC4960,
-        //   Appendix B [8].
+        //   Appendix B.
         // - put the resultant value into the checksum field, and leave the rest of
         //   the bits unchanged.
 
-        // add zeroed checksum field to TLVs
+        // Add zeroed checksum field to TLVs.
         self.add_typed_tlv(Crc32c::default());
 
-        // write PROXY header to buffer
+        // Write PROXY header to buffer.
         let mut buf = Vec::new();
         self.write_to(&mut buf).unwrap();
 
-        // calculate CRC on buffer and update CRC TLV
+        // Calculate CRC on buffer and update CRC TLV.
         let crc_calc = crc32fast::hash(&buf);
         self.tlvs.last_mut().unwrap().1 = crc_calc.to_be_bytes().to_smallvec();
-
-        tracing::debug!("checksum is {}", crc_calc);
     }
 
     /// Validates the CRC32c TLV, returning `None` when no CRC32c TLV is present.
     pub fn validate_crc32c_tlv(&self) -> Option<bool> {
-        // extract crc32c TLV or exit early if none is present
-        let crc_sent = self
-            .tlvs
-            .iter()
-            .filter_map(|(typ, value)| Crc32c::try_from_parts(*typ, value))
-            .next()?;
+        // Extract CRC32c TLV or exit early if none is present.
+        let crc_sent = self.typed_tlv::<Crc32c>()?;
 
         // If the checksum is provided as part of the PROXY header and the checksum
         // functionality is supported by the receiver, the receiver MUST:
-        //  - store the received CRC32c checksum value aside.
-        //  - replace the 32 bits of the checksum field in the received PROXY header with
-        //    all '0's and calculate a CRC32c checksum value of the whole PROXY header.
-        //  - verify that the calculated CRC32c checksum is the same as the received
-        //    CRC32c checksum. If it is not, the receiver MUST treat the TCP connection
-        //    providing the header as invalid.
+        // - store the received CRC32c checksum value aside.
+        // - replace the 32 bits of the checksum field in the received PROXY header with
+        //   all `0`s and calculate a CRC32c checksum value of the whole PROXY header.
+        // - verify that the calculated CRC32c checksum is the same as the received
+        //   CRC32c checksum. If it is not, the receiver MUST treat the TCP connection
+        //   providing the header as invalid.
         // The default procedure for handling an invalid TCP connection is to abort it.
-
         let mut this = self.clone();
         for (typ, value) in this.tlvs.iter_mut() {
             if Crc32c::try_from_parts(*typ, value).is_some() {
@@ -209,6 +371,166 @@ impl Header {
     }
 }
 
+fn parse(slice: &[u8]) -> Result<(&[u8], Header), ParseError> {
+    if slice.len() < 16 {
+        return Err(parse_err("incomplete PROXY v2 fixed header"));
+    }
+
+    if slice[..12] != SIGNATURE {
+        return Err(parse_err("missing PROXY v2 signature"));
+    }
+
+    let ver_cmd = slice[12];
+    if ver_cmd >> 4 != 0x2 {
+        return Err(parse_err("invalid PROXY v2 version"));
+    }
+
+    let command =
+        Command::from_v2_lo(ver_cmd & 0x0f).ok_or_else(|| parse_err("invalid command"))?;
+
+    let fam_proto = slice[13];
+    let address_family = AddressFamily::from_v2_hi(fam_proto >> 4)
+        .ok_or_else(|| parse_err("invalid address family"))?;
+    let transport_protocol = TransportProtocol::from_v2_lo(fam_proto & 0x0f)
+        .ok_or_else(|| parse_err("invalid transport protocol"))?;
+
+    let len = u16::from_be_bytes([slice[14], slice[15]]) as usize;
+    let end = 16 + len;
+    if slice.len() < end {
+        return Err(parse_err("incomplete PROXY v2 variable header"));
+    }
+
+    let payload = &slice[16..end];
+    let rest = &slice[end..];
+    let addr_len = address_len(address_family, transport_protocol)?;
+
+    if payload.len() < addr_len {
+        return Err(parse_err("PROXY v2 address block is shorter than required"));
+    }
+
+    let addresses = parse_addresses(address_family, transport_protocol, &payload[..addr_len])?;
+    let tlvs = parse_tlvs(&payload[addr_len..])?;
+
+    Ok((
+        rest,
+        Header {
+            command,
+            transport_protocol,
+            addresses,
+            tlvs,
+        },
+    ))
+}
+
+fn address_len(
+    address_family: AddressFamily,
+    transport_protocol: TransportProtocol,
+) -> Result<usize, ParseError> {
+    match (address_family, transport_protocol) {
+        (AddressFamily::Unspecified, TransportProtocol::Unspecified) => Ok(0),
+        (AddressFamily::Inet, TransportProtocol::Stream | TransportProtocol::Datagram) => Ok(12),
+        (AddressFamily::Inet6, TransportProtocol::Stream | TransportProtocol::Datagram) => Ok(36),
+        (AddressFamily::Unix, TransportProtocol::Stream | TransportProtocol::Datagram) => {
+            Ok(UNIX_ADDR_LEN * 2)
+        }
+        _ => Err(parse_err(
+            "invalid address family and transport protocol combination",
+        )),
+    }
+}
+
+fn parse_addresses(
+    address_family: AddressFamily,
+    transport_protocol: TransportProtocol,
+    payload: &[u8],
+) -> Result<Addresses, ParseError> {
+    match (address_family, transport_protocol) {
+        (AddressFamily::Unspecified, TransportProtocol::Unspecified) => Ok(Addresses::Unspecified),
+        (AddressFamily::Inet, TransportProtocol::Stream | TransportProtocol::Datagram) => {
+            Ok(Addresses::Inet {
+                source: SocketAddr::from((
+                    Ipv4Addr::new(payload[0], payload[1], payload[2], payload[3]),
+                    u16::from_be_bytes([payload[8], payload[9]]),
+                )),
+                destination: SocketAddr::from((
+                    Ipv4Addr::new(payload[4], payload[5], payload[6], payload[7]),
+                    u16::from_be_bytes([payload[10], payload[11]]),
+                )),
+            })
+        }
+        (AddressFamily::Inet6, TransportProtocol::Stream | TransportProtocol::Datagram) => {
+            let source_ip =
+                Ipv6Addr::from(<[u8; 16]>::try_from(&payload[..16]).expect("16-byte IPv6 source"));
+            let destination_ip = Ipv6Addr::from(
+                <[u8; 16]>::try_from(&payload[16..32]).expect("16-byte IPv6 destination"),
+            );
+
+            Ok(Addresses::Inet {
+                source: SocketAddr::from((
+                    source_ip,
+                    u16::from_be_bytes([payload[32], payload[33]]),
+                )),
+                destination: SocketAddr::from((
+                    destination_ip,
+                    u16::from_be_bytes([payload[34], payload[35]]),
+                )),
+            })
+        }
+        (AddressFamily::Unix, TransportProtocol::Stream | TransportProtocol::Datagram) => {
+            let source = Box::new(
+                <[u8; UNIX_ADDR_LEN]>::try_from(&payload[..UNIX_ADDR_LEN])
+                    .expect("108-byte UNIX source"),
+            );
+            let destination = Box::new(
+                <[u8; UNIX_ADDR_LEN]>::try_from(&payload[UNIX_ADDR_LEN..])
+                    .expect("108-byte UNIX destination"),
+            );
+
+            Ok(Addresses::Unix {
+                source,
+                destination,
+            })
+        }
+        _ => Err(parse_err(
+            "invalid address family and transport protocol combination",
+        )),
+    }
+}
+
+fn parse_tlvs(mut payload: &[u8]) -> Result<RawTlvs, ParseError> {
+    let mut tlvs = SmallVec::new();
+
+    while !payload.is_empty() {
+        if payload.len() < 3 {
+            return Err(parse_err("incomplete PROXY v2 TLV header"));
+        }
+
+        let typ = payload[0];
+        let len = u16::from_be_bytes([payload[1], payload[2]]) as usize;
+        payload = &payload[3..];
+
+        if payload.len() < len {
+            return Err(parse_err("incomplete PROXY v2 TLV value"));
+        }
+
+        tlvs.push((typ, SmallVec::from_slice(&payload[..len])));
+        payload = &payload[len..];
+    }
+
+    Ok(tlvs)
+}
+
+fn write_ip_bytes_to(wrt: &mut impl io::Write, ip: IpAddr) -> io::Result<()> {
+    match ip {
+        IpAddr::V4(ip) => wrt.write_all(&ip.octets()),
+        IpAddr::V6(ip) => wrt.write_all(&ip.octets()),
+    }
+}
+
+fn parse_err(message: &'static str) -> ParseError {
+    ParseError::invalid(message)
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::Ipv6Addr;
@@ -221,11 +543,11 @@ mod tests {
     #[test]
     fn write_v2_no_tlvs() {
         let mut exp = Vec::new();
-        exp.extend_from_slice(&SIGNATURE); // 0-11
-        exp.extend_from_slice(&[0x21, 0x11]); // 12-13
-        exp.extend_from_slice(&[0x00, 0x0C]); // 14-15
-        exp.extend_from_slice(&[127, 0, 0, 1, 127, 0, 0, 2]); // 16-23
-        exp.extend_from_slice(&[0x04, 0xd2, 0x00, 80]); // 24-27
+        exp.extend_from_slice(&SIGNATURE);
+        exp.extend_from_slice(&[0x21, 0x11]);
+        exp.extend_from_slice(&[0x00, 0x0C]);
+        exp.extend_from_slice(&[127, 0, 0, 1, 127, 0, 0, 2]);
+        exp.extend_from_slice(&[0x04, 0xd2, 0x00, 80]);
 
         let header = Header::new(
             Command::Proxy,
@@ -240,20 +562,45 @@ mod tests {
     }
 
     #[test]
+    fn parse_v2_no_tlvs() {
+        let mut bytes = Header::new_tcp_ipv4_proxy(
+            SocketAddr::from(([127, 0, 0, 1], 1234)),
+            SocketAddr::from(([127, 0, 0, 2], 80)),
+        )
+        .to_vec();
+        bytes.extend_from_slice(b"GET /");
+
+        let (rest, header) = Header::try_from_bytes(&bytes).unwrap();
+
+        assert_eq!(rest, b"GET /");
+        assert_eq!(header.command(), Command::Proxy);
+        assert_eq!(header.transport_protocol(), TransportProtocol::Stream);
+        assert_eq!(header.address_family(), AddressFamily::Inet);
+        assert_eq!(
+            header.source_addr().unwrap(),
+            SocketAddr::from(([127, 0, 0, 1], 1234))
+        );
+        assert_eq!(
+            header.destination_addr().unwrap(),
+            SocketAddr::from(([127, 0, 0, 2], 80))
+        );
+    }
+
+    #[test]
     fn write_v2_ipv6_tlv_noop() {
         let mut exp = Vec::new();
-        exp.extend_from_slice(&SIGNATURE); // 0-11
-        exp.extend_from_slice(&[0x20, 0x11]); // 12-13
-        exp.extend_from_slice(&[0x00, 0x28]); // 14-15
-        exp.extend_from_slice(&hex!("00000000000000000000000000000001")); // 16-31
-        exp.extend_from_slice(&hex!("000102030405060708090A0B0C0D0E0F")); // 32-45
-        exp.extend_from_slice(&[0x00, 80, 0xff, 0xff]); // 45-49
-        exp.extend_from_slice(&[0x04, 0x00, 0x01, 0x00]); // 50-53 NOOP TLV
+        exp.extend_from_slice(&SIGNATURE);
+        exp.extend_from_slice(&[0x20, 0x21]);
+        exp.extend_from_slice(&[0x00, 0x28]);
+        exp.extend_from_slice(&hex!("00000000000000000000000000000001"));
+        exp.extend_from_slice(&hex!("000102030405060708090A0B0C0D0E0F"));
+        exp.extend_from_slice(&[0x00, 80, 0xff, 0xff]);
+        exp.extend_from_slice(&[0x04, 0x00, 0x01, 0x00]);
 
         let mut header = Header::new(
             Command::Local,
             TransportProtocol::Stream,
-            AddressFamily::Inet,
+            AddressFamily::Inet6,
             SocketAddr::from((Ipv6Addr::LOCALHOST, 80)),
             SocketAddr::from((
                 Ipv6Addr::from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
@@ -268,22 +615,37 @@ mod tests {
     }
 
     #[test]
-    fn write_v2_tlv_c2c() {
-        let mut exp = Vec::new();
-        exp.extend_from_slice(&SIGNATURE); // 0-11
-        exp.extend_from_slice(&[0x21, 0x11]); // 12-13
-        exp.extend_from_slice(&[0x00, 0x13]); // 14-15
-        exp.extend_from_slice(&[127, 0, 0, 1, 127, 0, 0, 1]); // 16-23
-        exp.extend_from_slice(&[0x00, 80, 0x00, 80]); // 24-27
-        exp.extend_from_slice(&[0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00]); // 28-35 TLV crc32c
+    fn parse_v2_unspecified_with_tlv() {
+        let mut header = Header::new_unspecified(Command::Local);
+        header.add_tlv(0x05, b"abc123");
 
+        let (_rest, parsed) = Header::try_from_bytes(&header.to_vec()).unwrap();
+
+        assert_eq!(parsed.address_family(), AddressFamily::Unspecified);
+        assert_eq!(parsed.source_addr(), None);
+        assert_eq!(
+            parsed.tlvs().collect::<Vec<_>>(),
+            vec![(0x05, b"abc123".as_slice())]
+        );
+    }
+
+    #[test]
+    fn write_v2_tlv_crc32c() {
+        let mut exp = Vec::new();
+        exp.extend_from_slice(&SIGNATURE);
+        exp.extend_from_slice(&[0x21, 0x11]);
+        exp.extend_from_slice(&[0x00, 0x13]);
+        exp.extend_from_slice(&[127, 0, 0, 1, 127, 0, 0, 1]);
+        exp.extend_from_slice(&[0x00, 80, 0x00, 80]);
+        exp.extend_from_slice(&[0x03, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00]);
+
+        // Correct checksum calculated manually.
         assert_eq!(
             crc32fast::hash(&exp),
-            // correct checksum calculated manually
             u32::from_be_bytes([0x08, 0x70, 0x17, 0x7b]),
         );
 
-        // re-assign actual checksum to last 4 bytes of expected byte array
+        // Re-assign actual checksum to last 4 bytes of expected byte array.
         exp[31..35].copy_from_slice(&[0x08, 0x70, 0x17, 0x7b]);
 
         let mut header = Header::new(
@@ -299,16 +661,16 @@ mod tests {
             "header doesn't have CRC TLV added yet"
         );
 
-        // add crc32c TLV to header
-        header.add_crc23c_checksum();
+        // Add CRC32c TLV to header.
+        header.add_crc32c_checksum();
 
         assert_eq!(header.v2_len(), 12 + 7);
         assert_eq!(header.to_vec(), exp);
 
-        // struct can self-validate checksum
+        // Struct can self-validate checksum.
         assert_eq!(header.validate_crc32c_tlv().unwrap(), true);
 
-        // mangle crc32c TLV and assert that validate now fails
+        // Mangle CRC32c TLV and assert that validate now fails.
         *header.tlvs.last_mut().unwrap().1.last_mut().unwrap() = 0x00;
         assert_eq!(header.validate_crc32c_tlv().unwrap(), false);
     }


### PR DESCRIPTION
Adds PROXY protocol v2 header parsing and fuller encoding support for IPv4, IPv6, unspecified, UNIX address blocks, raw TLVs, typed TLV lookup, and CRC32C checks.