### PR TITLE
Add proxy protocol changelog entries

### DIFF
--- a/actix-proxy-protocol/CHANGELOG.md
+++ b/actix-proxy-protocol/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.88.
+- Add PROXY protocol v1 parsing for IPv4, IPv6, and UNKNOWN headers.
+- Add PROXY protocol v2 parsing and encoding for IPv4, IPv6, unspecified, and UNIX address blocks.
+- Add `Header::add_crc32c_checksum` for writing PROXY protocol v2 CRC32C checksum TLVs.
+- Add typed PROXY protocol v2 TLV helpers for ALPN, authority, CRC32C, NOOP, unique ID, SSL, and NETNS values.
+- Add a transparent stream wrapper and Actix acceptor for consuming leading PROXY protocol headers before delegating to the wrapped stream.
+- Add a TCP proxy example that can add PROXY v1 or v2 headers and consume incoming PROXY protocol headers.
 
 ## 0.1.0
 


### PR DESCRIPTION
Adds Unreleased changelog entries for the public PROXY protocol changes: v1 parsing, v2 parsing and encoding, typed v2 TLV helpers, transparent stream wrapping, Actix acceptor support, and the TCP proxy example.