### PR TITLE
Remove redundant proxy protocol imports

### DIFF
--- a/actix-proxy-protocol/src/tlv.rs
+++ b/actix-proxy-protocol/src/tlv.rs
@@ -1,6 +1,6 @@
 //! Type-length-value helpers for PROXY protocol v2 headers.
 
-use std::{borrow::Cow, str};
+use std::borrow::Cow;
 
 const PP2_TYPE_ALPN: u8 = 0x01; //           done
 const PP2_TYPE_AUTHORITY: u8 = 0x02; //      done

--- a/actix-proxy-protocol/src/tlv/crc32c.rs
+++ b/actix-proxy-protocol/src/tlv/crc32c.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, convert::TryFrom};
+use std::borrow::Cow;
 
 use super::{PP2_TYPE_CRC32C, Tlv};
 

--- a/actix-proxy-protocol/src/tlv/ssl.rs
+++ b/actix-proxy-protocol/src/tlv/ssl.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, convert::TryFrom, str};
+use std::{borrow::Cow, str};
 
 use super::Tlv;
 


### PR DESCRIPTION
Removes redundant imports from the PROXY protocol TLV modules now that the crate uses Rust 2024 prelude items.