### PR TITLE
chore: use shared Rust Just MSRV recipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,17 @@ jobs:
         with:
           tool: just,cargo-hack,cargo-nextest,cargo-ci-cache-clean
 
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+        with:
+          extra-conf: lazy-trees = true
+
+      - name: Set up FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+
       - name: workaround MSRV issues
         if: matrix.version.name == 'msrv'
         run: just downgrade-for-msrv
@@ -79,6 +90,17 @@ jobs:
         uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: just
+
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+        with:
+          extra-conf: lazy-trees = true
+
+      - name: Set up FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
 
       - name: doc tests
         run: just test-docs

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,6 +30,17 @@ jobs:
         with:
           tool: just,cargo-llvm-cov
 
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+        with:
+          extra-conf: lazy-trees = true
+
+      - name: Set up FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@77c6bddd7d747943530aaa578c57f233ee5d920e # v3.21.8
+
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+
       - name: Generate code coverage
         run: just test-coverage-codecov
 

--- a/flake.lock
+++ b/flake.lock
@@ -52,7 +52,31 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "x52": "x52"
+      }
+    },
+    "x52": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785501466,
+        "narHash": "sha256-EmBn1w7+V9l1P4XqFLSZDVOxMtMIIGxUrJawlrvaO5U=",
+        "owner": "x52dev",
+        "repo": "nix",
+        "rev": "7f726782d3870c1d11a9480ebeb9a34a693d4a17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "x52dev",
+        "repo": "nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,17 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    x52 = {
+      url = "github:x52dev/nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
+    };
   };
 
   outputs = inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ inputs.x52.flakeModules.default ];
+
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       perSystem = { pkgs, config, inputs', system, lib, ... }: {
         formatter = pkgs.nixpkgs-fmt;
@@ -17,13 +24,18 @@
             pkgs.cargo-nextest
             pkgs.cargo-outdated
             pkgs.fd
+            pkgs.jq
             pkgs.just
             pkgs.nodePackages.prettier
+            pkgs.openssl
+            pkgs.pkg-config
             pkgs.taplo
             pkgs.watchexec
           ] ++ lib.optional pkgs.stdenv.isDarwin [
             pkgs.pkgsBuildHost.libiconv
           ];
+
+          shellHook = config.x52.justRust.shellHook;
         };
       };
     };

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+import '.toolchain/rust.just'
+
 _list:
     @just --list
 
@@ -23,13 +25,6 @@ fmt: update-readmes
 update-readmes:
     cd ./russe && cargo rdme --force
     cd ./err-report && cargo rdme --force
-
-msrv := ```
-    cargo --frozen metadata --no-deps --format-version=1 \
-    | jq -r 'first(.packages[] | select(.source == null and .rust_version)) | .rust_version' \
-    | sed -E 's/^1\.([0-9]{2})$/1\.\1\.0/'
-```
-msrv_rustup := "+" + msrv
 
 # Downgrade dev-dependencies necessary to run MSRV checks/tests.
 [private]


### PR DESCRIPTION
## Summary

- import the shared Rust Just flake-parts module
- replace the local MSRV definitions with `.toolchain/rust.just`
- retain the project-selected `pkgs.just` and add explicit `jq` support for the shared recipe

## Why

The shared recipe selects the lowest declared MSRV across workspace members and fails clearly when the workspace metadata is incomplete. This replaces the local first-package variant while preserving the current evaluated MSRV.

## Validation

- `nix develop -c just --list`
- verified `.toolchain/rust.just` is a symlink
- evaluated the existing MSRV through the shared recipe
- `nix develop -c just --unstable --fmt --check`
- `nix flake check --no-build`
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/*.yml`
