### PR TITLE
chore: add monthly Nix Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     schedule:
       interval: weekly
     versioning-strategy: lockfile-only
+  - package-ecosystem: nix
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Configure Dependabot to update Nix inputs monthly. This does not change any existing flake lockfile pins.