### PR TITLE
ci: key Rust cache by Nix lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: ${{ matrix.version.version }}
+          cache-key: ${{ hashFiles('flake.lock') }}
 
       - name: Install just,cargo-hack,cargo-nextest,cargo-ci-cache-clean
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
@@ -85,6 +86,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: nightly
+          cache-key: ${{ hashFiles('flake.lock') }}
 
       - name: Install just
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: llvm-tools
+          cache-key: ${{ hashFiles('flake.lock') }}
 
       - name: Install just, cargo-llvm-cov
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7


### PR DESCRIPTION
## Summary

- Key Nix-backed Rust caches with flake.lock.
- Prevent restored build scripts from using an incompatible Nix runtime.

## Root cause

The nixpkgs update changed the native runtime. The Rust cache key did not include flake.lock, so Documentation Tests and Coverage restored build scripts from the old runtime. Cargo then failed to execute those scripts with os error 2.

## Validation

- nix develop -c just test-docs
- nix develop -c just check