### PR TITLE
fix(ci): correct setup-mold version comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # staging
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install Rust (${{ matrix.version.name }})
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0


### PR DESCRIPTION
## Summary

- Change the setup-mold version comment from `# staging` to `# v1`.
- Keep the pinned setup-mold commit unchanged.

## Why

zizmor reports that `.github/workflows/ci.yml:42` has a mismatched version comment. The pinned commit belongs to the `v1` tag, while the `staging` tag now points to a different commit. This blocks the GitHub Actions Security check on actix-web-lab Dependabot PRs #413–#417.

## Validation

- `nix develop -c just check`
- `git diff --check`
