### PR TITLE
fix!: apply HSTS to RedirectHttps error responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+        uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
 
       - name: Install Rust (${{ matrix.version.name }})
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
  "md-5",
  "md4",
  "pin-project-lite",
- "sha1",
+ "sha1 0.10.7",
  "sha2",
  "sha3",
  "subtle",
@@ -113,7 +113,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.10.2",
- "sha1",
+ "sha1 0.11.0",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.14.0"
+version = "4.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df09e2d9239703dd64056359c920c7f3fba6535ec61a0059e0f44e095ffe02b4"
+checksum = "bbacab3593b6b4f7be815076fc52d60a83c873426824675417e2abdd229e2e36"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -368,7 +368,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "hmac",
- "http 1.4.2",
+ "http 0.2.12",
  "impl-more 0.3.5",
  "itertools",
  "local-channel",
@@ -3017,6 +3017,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/actix-proxy-protocol/src/service/acceptor.rs
+++ b/actix-proxy-protocol/src/service/acceptor.rs
@@ -77,7 +77,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use actix_service::Service as _;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
     use super::*;

--- a/actix-proxy-protocol/src/service/stream.rs
+++ b/actix-proxy-protocol/src/service/stream.rs
@@ -257,7 +257,7 @@ where
 mod tests {
     use std::net::SocketAddr;
 
-    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, duplex};
+    use tokio::io::{AsyncWriteExt as _, duplex};
 
     use super::*;
     use crate::{AddressFamily, Command, TransportProtocol};

--- a/actix-web-lab/CHANGELOG.md
+++ b/actix-web-lab/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Apply configured HSTS headers to error responses returned by wrapped services.
+- `RedirectHttps` now requires wrapped services to use `actix_web::Error` as their error type.
+
 ## 0.26.0
 
 - Add `middleware::HostAllowlist` and `RedirectHttps::allow_hosts()` to harden redirect middleware against host header poisoning when configured.

--- a/actix-web-lab/Cargo.toml
+++ b/actix-web-lab/Cargo.toml
@@ -52,7 +52,7 @@ actix-http = "3.10"
 actix-router = "0.5"
 actix-service = "2"
 actix-utils = "3"
-actix-web = { version = "4.9", default-features = false }
+actix-web = { version = "4.15", default-features = false }
 ahash = "0.8"
 arc-swap = "1.1"
 bytes = "1"
@@ -90,7 +90,7 @@ actix-files = { version = "0.6", optional = true }
 [dev-dependencies]
 actix-web-lab-derive = "=0.26.0"
 
-actix-web = { version = "4", features = ["rustls-0_23"] }
+actix-web = { version = "4.15", features = ["rustls-0_23"] }
 async_zip = { version = "0.0.18", features = ["deflate", "tokio"] }
 base64 = "0.22"
 digest = "0.10"

--- a/actix-web-lab/src/catch_panic.rs
+++ b/actix-web-lab/src/catch_panic.rs
@@ -99,7 +99,7 @@ mod tests {
     use actix_web::{
         App, Error,
         body::{MessageBody, to_bytes},
-        dev::{Service as _, ServiceFactory},
+        dev::ServiceFactory,
         http::StatusCode,
         test, web,
     };

--- a/actix-web-lab/src/panic_reporter.rs
+++ b/actix-web-lab/src/panic_reporter.rs
@@ -123,9 +123,7 @@ mod tests {
     };
 
     use actix_web::{
-        App,
-        dev::Service as _,
-        test,
+        App, test,
         web::{self, ServiceConfig},
     };
 

--- a/actix-web-lab/src/redirect_to_https.rs
+++ b/actix-web-lab/src/redirect_to_https.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use actix_web::{
-    HttpResponse, Responder as _,
+    Error, HttpResponse, Responder as _,
     body::EitherBody,
     dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready},
     http::header::TryIntoHeaderPair,
@@ -96,10 +96,10 @@ impl RedirectHttps {
 
 impl<S, B> Transform<S, ServiceRequest> for RedirectHttps
 where
-    S: Service<ServiceRequest, Response = ServiceResponse<B>> + 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
 {
     type Response = ServiceResponse<EitherBody<B, ()>>;
-    type Error = S::Error;
+    type Error = Error;
     type Transform = RedirectHttpsMiddleware<S>;
     type InitError = ();
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
@@ -126,10 +126,10 @@ pub struct RedirectHttpsMiddleware<S> {
 
 impl<S, B> Service<ServiceRequest> for RedirectHttpsMiddleware<S>
 where
-    S: Service<ServiceRequest, Response = ServiceResponse<B>> + 'static,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
 {
     type Response = ServiceResponse<EitherBody<B, ()>>;
-    type Error = S::Error;
+    type Error = Error;
     type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     forward_ready!(service);
@@ -183,12 +183,23 @@ where
 
             let req = ServiceRequest::from_parts(req, pl);
 
-            // TODO: apply HSTS header to error case
+            service
+                .call(req)
+                .await
+                .map(|mut res| {
+                    apply_hsts(res.response_mut(), hsts);
+                    res.map_into_left_body()
+                })
+                .map_err(|mut err| {
+                    if let Some(hsts) = hsts {
+                        err.add_response_mapper(move |mut res| {
+                            apply_hsts(&mut res, Some(hsts));
+                            res
+                        });
+                    }
 
-            service.call(req).await.map(|mut res| {
-                apply_hsts(res.response_mut(), hsts);
-                res.map_into_left_body()
-            })
+                    err
+                })
         })
     }
 }
@@ -291,6 +302,24 @@ mod tests {
 
         let req = test_request!(GET "https://localhost:443/").to_srv_request();
         let res = test::call_service(&app, req).await;
+        assert!(res.headers().contains_key(StrictTransportSecurity::name()));
+    }
+
+    #[actix_web::test]
+    async fn hsts_on_error_response() {
+        let srv = actix_service::fn_service(|_req: ServiceRequest| async {
+            Err::<ServiceResponse, _>(actix_web::error::ErrorInternalServerError("boom"))
+        });
+        let app = RedirectHttps::with_hsts(StrictTransportSecurity::recommended())
+            .new_transform(srv)
+            .await
+            .unwrap();
+
+        let req = test_request!(GET "https://localhost/").to_srv_request();
+        let err = test::try_call_service(&app, req).await.unwrap_err();
+        let res = err.error_response();
+
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert!(res.headers().contains_key(StrictTransportSecurity::name()));
     }
 


### PR DESCRIPTION
## Summary

- Apply configured HSTS headers to propagated error responses in `RedirectHttps`.
- Require `actix-web` 4.15 for `Error::add_response_mapper()`.
- Add regression coverage and breaking-release changelog entries.

## Breaking change

`RedirectHttps` now requires wrapped services to use `actix_web::Error` as their error type.
